### PR TITLE
Adjust spacing for text and maintain consistent box size

### DIFF
--- a/crypto_style.css
+++ b/crypto_style.css
@@ -1,121 +1,129 @@
 /*  Counter Section  */
 
-#counter {    
-    background-color: #ffb400;
-    color: #39fc03;
-    display: block;
-    overflow: hidden;
-    text-align: center;
-    padding: 100px 0;
+#counter {
+  background-color: #ffb400;
+  color: #39fc03;
+  display: block;
+  overflow: hidden;
+  text-align: center;
+  padding: 100px 0;
 }
 #counter .count {
-    padding: 50px;
-    background: rgba(255, 255, 255, 0.1);
-    color: #39fc03;
-    text-align: center;
+  padding: 50px 20px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #39fc03;
+  text-align: center;
 }
-.count h4 {
-    color: #39fc03;
-	font-size: 16px;
-	margin-top: 0;
+
+#counter .count h4 {
+  color: #39fc03;
+  font-size: 16px;
+  margin: 0;
+  line-height: 1.3;
 }
 #counter .count .fa {
-    font-size: 40px;
-    display: block;
-    color: #39fc03;
+  font-size: 40px;
+  display: block;
+  color: #39fc03;
 }
 #counter .number {
-    font-size: 30px;
-    font-weight: 700;
-    margin: 0;
+  font-size: 30px;
+  font-weight: 700;
+  margin: 15px 0;
+  line-height: 1.2;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
 }
+
 /*  Pricing Section  */
 
 #pricing {
-    background: #f7f7f7;
+  background: #f7f7f7;
 }
 .pricing-items {
-    padding-top: 50px;
+  padding-top: 50px;
 }
 .pricing-item {
-    background: #fff;
-    position: relative;
-    box-shadow: 0 0 9px 0 rgba(130, 121, 121, .2);
-    padding: 50px 0px;
-    border-top-right-radius: 2em;
-    border-bottom-left-radius: 2em;
+  background: #fff;
+  position: relative;
+  box-shadow: 0 0 9px 0 rgba(130, 121, 121, 0.2);
+  padding: 50px 0px;
+  border-top-right-radius: 2em;
+  border-bottom-left-radius: 2em;
 }
 .pricing-item.active {
-    top: -50px;
+  top: -50px;
 }
 .price-list li {
-    list-style: none;
-    margin-bottom: 15px;
+  list-style: none;
+  margin-bottom: 15px;
 }
 
 .price-list .price {
-    font-size: 30px;
-    font-weight: bold;
+  font-size: 30px;
+  font-weight: bold;
 }
 .pricing-item .ribbon {
-    margin: -50px 0 20px;
-    display: block;
-    background-color: #ffb400;
-    padding: 15px 0 2px;
-    opacity: 0.8;
-    border-top-right-radius: 2em;
+  margin: -50px 0 20px;
+  display: block;
+  background-color: #ffb400;
+  padding: 15px 0 2px;
+  opacity: 0.8;
+  border-top-right-radius: 2em;
 }
 .pricing-item:hover .ribbon {
-    background-color: #ffb400;
-	opacity: 1;
+  background-color: #ffb400;
+  opacity: 1;
 }
 .pricing-item.active .ribbon {
-    background-color: #ffb400;
-	opacity: 1;
+  background-color: #ffb400;
+  opacity: 1;
 }
 .pricing-item .ribbon p {
-    color: #fff;
-    font-size: 22px;
-    margin: 0 0 10px;
-    font-weight: 600;
+  color: #fff;
+  font-size: 22px;
+  margin: 0 0 10px;
+  font-weight: 600;
 }
-.pricing-item.active .price-list li, .pricing-item:hover .price-list li {
-    color: #848181;;
+.pricing-item.active .price-list li,
+.pricing-item:hover .price-list li {
+  color: #848181;
 }
 ul.price-list {
-    margin-bottom: 30px;
-    padding: 0;
+  margin-bottom: 30px;
+  padding: 0;
 }
 .btn-price {
-    display: inline-block;
-    position: relative;
-    text-align: center;
-    text-transform: uppercase;
-    padding: 14px 40px;
-    -webkit-border-radius: 26px;
-    -moz-border-radius: 26px;
-    -o-border-radius: 26px;
-    border-radius: 26px;
-    border: 1px solid #848181;
-    background-color: transparent;
-    color: #848181;
+  display: inline-block;
+  position: relative;
+  text-align: center;
+  text-transform: uppercase;
+  padding: 14px 40px;
+  -webkit-border-radius: 26px;
+  -moz-border-radius: 26px;
+  -o-border-radius: 26px;
+  border-radius: 26px;
+  border: 1px solid #848181;
+  background-color: transparent;
+  color: #848181;
 }
 .pricing-item:hover .btn-price,
 .active .btn-price {
-    border: 1px solid #ffb400;
-    background-color: #ffb400;
-    color: #fff;
+  border: 1px solid #ffb400;
+  background-color: #ffb400;
+  color: #fff;
 }
 .btn-price:focus {
-    background-color: transparent;
-    text-decoration: none;
+  background-color: transparent;
+  text-decoration: none;
 }
 @media only screen and (max-width: 767px) {
-    .pricing-items {
-        padding-top: 0;
-    }
-    .pricing-item.active {
-        top: 20px;
-        margin-bottom: 40px;
-    }
+  .pricing-items {
+    padding-top: 0;
+  }
+  .pricing-item.active {
+    top: 20px;
+    margin-bottom: 40px;
+  }
 }

--- a/crypto_style.css
+++ b/crypto_style.css
@@ -1,129 +1,69 @@
-/*  Counter Section  */
+:root {
+  --background-color: #f9d976;
+  --text-color: #3cd070;
+}
 
 #counter {
-  background-color: #ffb400;
-  color: #39fc03;
+  min-height: 100vh;
+  background-color: var(--background-color);
+  color: var(--text-color);
   display: block;
   overflow: hidden;
   text-align: center;
   padding: 100px 0;
 }
+
 #counter .count {
   padding: 50px 20px;
   background: rgba(255, 255, 255, 0.1);
-  color: #39fc03;
+  color: var(--text-color);
   text-align: center;
 }
 
+#counter .count h4,
+#counter .count .fa,
 #counter .count h4 {
-  color: #39fc03;
-  font-size: 16px;
   margin: 0;
   line-height: 1.3;
+  font-size: 1.3rem;
 }
+
 #counter .count .fa {
-  font-size: 40px;
   display: block;
-  color: #39fc03;
 }
+
 #counter .number {
-  font-size: 30px;
   font-weight: 700;
   margin: 15px 0;
   line-height: 1.2;
   word-wrap: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
+  font-size: 2.3rem;
 }
 
-/*  Pricing Section  */
-
-#pricing {
-  background: #f7f7f7;
-}
-.pricing-items {
-  padding-top: 50px;
-}
-.pricing-item {
-  background: #fff;
-  position: relative;
-  box-shadow: 0 0 9px 0 rgba(130, 121, 121, 0.2);
-  padding: 50px 0px;
-  border-top-right-radius: 2em;
-  border-bottom-left-radius: 2em;
-}
-.pricing-item.active {
-  top: -50px;
-}
-.price-list li {
-  list-style: none;
-  margin-bottom: 15px;
+.money-display-box {
+  background: rgba(255, 255, 255, 0.25);
+  padding: 40px 60px 30px 60px;
+  margin-bottom: 20px;
+  min-width: 320px;
+  max-width: 700px;
+  width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+  color: var(--text-color);
+  font-weight: 700;
 }
 
-.price-list .price {
-  font-size: 30px;
-  font-weight: bold;
+.money-display-box .number {
+  font-weight: 800;
+  color: var(--text-color);
 }
-.pricing-item .ribbon {
-  margin: -50px 0 20px;
-  display: block;
-  background-color: #ffb400;
-  padding: 15px 0 2px;
-  opacity: 0.8;
-  border-top-right-radius: 2em;
-}
-.pricing-item:hover .ribbon {
-  background-color: #ffb400;
-  opacity: 1;
-}
-.pricing-item.active .ribbon {
-  background-color: #ffb400;
-  opacity: 1;
-}
-.pricing-item .ribbon p {
-  color: #fff;
-  font-size: 22px;
-  margin: 0 0 10px;
-  font-weight: 600;
-}
-.pricing-item.active .price-list li,
-.pricing-item:hover .price-list li {
-  color: #848181;
-}
-ul.price-list {
-  margin-bottom: 30px;
-  padding: 0;
-}
-.btn-price {
-  display: inline-block;
-  position: relative;
-  text-align: center;
-  text-transform: uppercase;
-  padding: 14px 40px;
-  -webkit-border-radius: 26px;
-  -moz-border-radius: 26px;
-  -o-border-radius: 26px;
-  border-radius: 26px;
-  border: 1px solid #848181;
-  background-color: transparent;
-  color: #848181;
-}
-.pricing-item:hover .btn-price,
-.active .btn-price {
-  border: 1px solid #ffb400;
-  background-color: #ffb400;
-  color: #fff;
-}
-.btn-price:focus {
-  background-color: transparent;
-  text-decoration: none;
-}
-@media only screen and (max-width: 767px) {
-  .pricing-items {
-    padding-top: 0;
-  }
-  .pricing-item.active {
-    top: 20px;
-    margin-bottom: 40px;
+
+@media (max-width: 767px) {
+  .money-display-box {
+    padding: 25px 10px 20px 10px;
+    min-width: unset;
+    width: 98%;
   }
 }

--- a/trump_crypto.html
+++ b/trump_crypto.html
@@ -16,24 +16,24 @@
   <body>
 <section id="counter" class="sec-padding">
         <div class="container">
-            <div class="row">
-                <div class="col-md-3 ">
-                    <div class="count"> <span class="fa fa-smile-o"></span>
+            <div class="row justify-content-center">
+                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
+                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
                         <p class="number" id="moneyDisplay">0</p>
                         <h4>Total Profit</h4> </div>
                 </div>
-                <div class="col-md-3 ">
-                    <div class="count"> <span class="fa fa-smile-o"></span>
+                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
+                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
                         <p class="number" id="tradingFees">100,000,000</p>
                         <h4>Trading Fees (Estimated)</h4> </div>
                 </div>
-                 <div class="col-md-3 ">
-                    <div class="count"> <span class="fa fa-smile-o"></span>
+                 <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
+                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
                         <p class="number" id="foreignPurchases">896</p>
                         <h4>Revenue from Foreign Purchases</h4> </div>
                 </div>
-                <div class="col-md-3 ">
-                    <div class="count"> <span class="fa fa-smile-o"></span>
+                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
+                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
                         <p class="number" id="WLFRevenue">777</p>
                         <h4>World Liberty Revenue</h4> </div>
                 </div>

--- a/trump_crypto.html
+++ b/trump_crypto.html
@@ -1,88 +1,119 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.7/dist/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-    </script>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+      integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/popper.js@1.14.7/dist/umd/popper.min.js"
+      integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/js/bootstrap.min.js"
+      integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+      crossorigin="anonymous"
+    ></script>
     <title>Professionalized Corruption Tracker</title>
-    <link rel="stylesheet" href="crypto_style.css">
+    <link rel="stylesheet" href="crypto_style.css" />
   </head>
   <body>
-<section id="counter" class="sec-padding">
-        <div class="container">
-            <div class="row justify-content-center">
-                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
-                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
-                        <p class="number" id="moneyDisplay">0</p>
-                        <h4>Total Profit</h4> </div>
-                </div>
-                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
-                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
-                        <p class="number" id="tradingFees">100,000,000</p>
-                        <h4>Trading Fees (Estimated)</h4> </div>
-                </div>
-                 <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
-                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
-                        <p class="number" id="foreignPurchases">896</p>
-                        <h4>Revenue from Foreign Purchases</h4> </div>
-                </div>
-                <div class="col-lg-3 col-md-6 col-sm-6 mb-4">
-                    <div class="count h-100 d-flex flex-column justify-content-center"> <span class="fa fa-smile-o"></span>
-                        <p class="number" id="WLFRevenue">777</p>
-                        <h4>World Liberty Revenue</h4> </div>
-                </div>
+    <section id="counter" class="sec-padding">
+      <div class="container">
+        <div class="row justify-content-center mb-4">
+          <div class="col-12">
+            <div
+              class="count money-display-box h-100 d-flex flex-column justify-content-center align-items-center"
+            >
+              <span class="fa fa-smile-o"></span>
+              <p class="number" id="moneyDisplay"></p>
+              <h4>Total Profit</h4>
             </div>
+          </div>
         </div>
+        <div class="row justify-content-center">
+          <div class="col-lg-4 col-md-6 col-sm-6 mb-4">
+            <div class="count h-100 d-flex flex-column justify-content-center">
+              <span class="fa fa-smile-o"></span>
+              <p class="number" id="tradingFees">100,000,000</p>
+              <h4>Trading Fees (Estimated)</h4>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 col-sm-6 mb-4">
+            <div class="count h-100 d-flex flex-column justify-content-center">
+              <span class="fa fa-smile-o"></span>
+              <p class="number" id="foreignPurchases">896</p>
+              <h4>Revenue from Foreign Purchases</h4>
+            </div>
+          </div>
+          <div class="col-lg-4 col-md-6 col-sm-6 mb-4">
+            <div class="count h-100 d-flex flex-column justify-content-center">
+              <span class="fa fa-smile-o"></span>
+              <p class="number" id="WLFRevenue">777</p>
+              <h4>World Liberty Revenue</h4>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
     <script>
-        
-const moneyDisplay = document.getElementById('moneyDisplay'); 
-let currentMoney = 0;
-const revenueFromTradingFees = 320000000; //https://www.nytimes.com/interactive/2025/07/02/business/donald-trump-wealth-net-worth.html
-// was 100,000,00, per Reuters: www.reuters.com/markets/currencies/trumps-meme-coin-made-nearly-100-million-trading-fees-small-traders-lost-money-2025-02-03/
-const revenueFromForeignPurchases = 100000000; // https://www.reuters.com/press-releases/aqua-1-announces-100m-strategic-world-liberty-financial-governance-token-purchase-to-help-shape-and-accelerate-decentralized-finance-adoption-2025-06-26/
-const worldLibertyTokenRevenue = 550000000; // https://www.nytimes.com/interactive/2025/07/02/business/donald-trump-wealth-net-worth.html
-$("#tradingFees").html(revenueFromTradingFees.toLocaleString()); 
-$("#foreignPurchases").html(revenueFromForeignPurchases.toLocaleString()); 
-$("#WLFRevenue").html(worldLibertyTokenRevenue.toLocaleString()); 
-const secondsInYear = 31536000; // 365 days in a year * 24 hours in a day * 60 minutes in an hour * 60 seconds in a minute
-                                // As a stand in for the number of periods increasing for holding the stablecoin collateral
-                                // in 1 month T-bills
-const oneMonthTBillRate = .0445; // pulling from here https://home.treasury.gov/resource-center/data-chart-center/interest-rates/TextView?type=daily_treasury_yield_curve&field_tdr_date_value=2025
-const perSecondRate = oneMonthTBillRate / secondsInYear
-let stableCoinPrinciple = 0.0;
-const qatariStableCoinPurchase =  2204586586.0;// https://www.coingecko.com/en/coins/usd1-wlfi// 2000000000; // www.nytimes.com/2025/05/01/us/politics/trump-cryptocurrency-usd1-dubai-conference-announcement.html
-const qatariPurchaseDate = new Date('2025.05.01'); // www.nytimes.com/2025/05/01/us/politics/trump-cryptocurrency-usd1-dubai-conference-announcement.html
-const qatariPurchaseDateTimestamp = Math.floor(qatariPurchaseDate.getTime() / 1000.0);
+      const moneyDisplay = document.getElementById("moneyDisplay");
+      let currentMoney = 0;
+      const revenueFromTradingFees = 320000000; //https://www.nytimes.com/interactive/2025/07/02/business/donald-trump-wealth-net-worth.html
+      // was 100,000,00, per Reuters: www.reuters.com/markets/currencies/trumps-meme-coin-made-nearly-100-million-trading-fees-small-traders-lost-money-2025-02-03/
+      const revenueFromForeignPurchases = 100000000; // https://www.reuters.com/press-releases/aqua-1-announces-100m-strategic-world-liberty-financial-governance-token-purchase-to-help-shape-and-accelerate-decentralized-finance-adoption-2025-06-26/
+      const worldLibertyTokenRevenue = 550000000; // https://www.nytimes.com/interactive/2025/07/02/business/donald-trump-wealth-net-worth.html
+      $("#tradingFees").html("$" + revenueFromTradingFees.toLocaleString());
+      $("#foreignPurchases").html(
+        "$" + revenueFromForeignPurchases.toLocaleString()
+      );
+      $("#WLFRevenue").html("$" + worldLibertyTokenRevenue.toLocaleString());
+      const secondsInYear = 31536000; // 365 days in a year * 24 hours in a day * 60 minutes in an hour * 60 seconds in a minute
+      // As a stand in for the number of periods increasing for holding the stablecoin collateral
+      // in 1 month T-bills
+      const oneMonthTBillRate = 0.0445; // pulling from here https://home.treasury.gov/resource-center/data-chart-center/interest-rates/TextView?type=daily_treasury_yield_curve&field_tdr_date_value=2025
+      const perSecondRate = oneMonthTBillRate / secondsInYear;
+      let stableCoinPrinciple = 0.0;
+      const qatariStableCoinPurchase = 2204586586.0; // https://www.coingecko.com/en/coins/usd1-wlfi// 2000000000; // www.nytimes.com/2025/05/01/us/politics/trump-cryptocurrency-usd1-dubai-conference-announcement.html
+      const qatariPurchaseDate = new Date("2025.05.01"); // www.nytimes.com/2025/05/01/us/politics/trump-cryptocurrency-usd1-dubai-conference-announcement.html
+      const qatariPurchaseDateTimestamp = Math.floor(
+        qatariPurchaseDate.getTime() / 1000.0
+      );
 
-stableCoinPrinciple = qatariStableCoinPurchase; // will need to add more based on current stablecoins in circulation
-const perSecondInterestEarned = perSecondRate * stableCoinPrinciple
+      stableCoinPrinciple = qatariStableCoinPurchase; // will need to add more based on current stablecoins in circulation
+      const perSecondInterestEarned = perSecondRate * stableCoinPrinciple;
 
-const increment = 100.0;
-const interval = 50.0; // Time in milliseconds
+      const increment = 100.0;
+      const interval = 50.0; // Time in milliseconds
 
-function updateMoneyDisplay() {
-    let currentTimestampInSeconds = Math.floor(Date.now() / 1000.0);
-    secondsOfInterest = (currentTimestampInSeconds - qatariPurchaseDateTimestamp)
-    interestEarned = (secondsOfInterest * perSecondInterestEarned);
-    currentMoney = revenueFromTradingFees + interestEarned;
-    console.log("perSecondProfit: " + interestEarned);
+      function updateMoneyDisplay() {
+        let currentTimestampInSeconds = Math.floor(Date.now() / 1000.0);
+        secondsOfInterest =
+          currentTimestampInSeconds - qatariPurchaseDateTimestamp;
+        interestEarned = secondsOfInterest * perSecondInterestEarned;
+        currentMoney = revenueFromTradingFees + interestEarned;
+        console.log("perSecondProfit: " + interestEarned);
 
-    // Use Intl.NumberFormat for currency formatting
-    const formattedMoney = currentMoney.toLocaleString();
+        // Use Intl.NumberFormat for currency formatting
+        const formattedMoney =
+          "$" + currentMoney.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 
-    moneyDisplay.textContent = formattedMoney;
-
-
-}
-
-const animationInterval = setInterval(updateMoneyDisplay, 1000.0);
+        moneyDisplay.textContent = formattedMoney;
+      }
+      updateMoneyDisplay();
+      const animationInterval = setInterval(updateMoneyDisplay, 1000.0);
     </script>
   </body>
 </html>


### PR DESCRIPTION
Few edits that maintain code style but improve visual balance.

- Remove extra <script> tag so I can lint html file
- Invoke updateMoneyDisplay() so proper amount shows on load instead of after 1 second
- Remove legacy tagging in css for pricing section
- Reduce redundant usage of hex codes, font sizes, etc
- Maintain visual style while reducing retina burn

Before:
<img width="1253" alt="Screenshot 2025-07-07 at 8 34 32 PM" src="https://github.com/user-attachments/assets/b9046407-9f97-4a26-80e1-b928a42981b5" />


After:
<img width="1278" alt="Screenshot 2025-07-08 at 10 58 46 AM" src="https://github.com/user-attachments/assets/075f8a4f-c91a-43bc-a7d2-0055014e79f6" />
